### PR TITLE
fix(cli): update test command in `dev` to vite version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": ""
   },
   "scripts": {
-    "dev": "concurrently \"yarn build --watch\" \"yarn storybook\" \"yarn test:watch\" ",
+    "dev": "concurrently \"yarn build --watch\" \"yarn storybook\" \"yarn test\" ",
     "build": "tsup --onSuccess \"yarn yalc publish\"",
     "type-check": "tsc",
     "lint": "eslint --ignore-path .gitignore \"{src,tests}/**/*.+(ts|js|tsx)\"",


### PR DESCRIPTION
I notice the test suit changed to vite, and the `test:watch` is not used anymore, but still in the `dev`

https://github.com/TimMikeladze/tsup-react-package-starter/commit/778c9c038880d61db489c5fbeab7d21d5382f9b6#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L20

btw, thank you @TimMikeladze for this cool project!